### PR TITLE
Use dH/dt with forecasting as figure of merit

### DIFF
--- a/instrument.py
+++ b/instrument.py
@@ -40,6 +40,12 @@ class ReflectometerBase(object):
     def intensity(self, x):
         pass
 
+    def meastime(self, x, totaltime):
+
+        f = np.array(x) ** 2
+
+        return totaltime * f / sum(f)
+
     def T(self, x):
         
         return self.x2a(x)
@@ -155,6 +161,12 @@ class MAGIK(ReflectometerBase):
     
         return np.array(incident_neutrons, ndmin=2).T
 
+    def meastime(self, x, totaltime):
+
+        f = 30.0 + 1250. * np.array(x) ** 2
+
+        return totaltime * f / sum(f)
+
     def T(self, x):
 
         x = np.array(x, ndmin=1)
@@ -233,6 +245,12 @@ class CANDOR(ReflectometerBase):
         incident_neutrons = [np.interp(news1, self.s1_intens_calib, intens) for intens in self.intens_calib.T]
     
         return np.array(incident_neutrons, ndmin=2).T
+
+    def meastime(self, x, totaltime):
+
+        f = 20.0 + 20000. * np.array(x) ** 3
+
+        return totaltime * f / sum(f)
 
     def get_slits(self, x):
         s1, s2, s3, _ = super().get_slits(x)

--- a/instrument.py
+++ b/instrument.py
@@ -216,7 +216,7 @@ class CANDOR(ReflectometerBase):
         #ps1 = np.polynomial.polynomial.polyfit(s1, intens, 1)
 
     def x2q(self, x):
-        return a2q(x, self.L(x))
+        return a2q(self.T(x), self.L(x))
 
     def x2a(self, x):
         return x

--- a/plot_entropy.py
+++ b/plot_entropy.py
@@ -123,6 +123,8 @@ def plot_entropy(tscale=None, min_time=None, control=None, experiments=[], label
     clegend_elements = []
     if labels is None:
         alllabels = [None for _ in range(len(experiments))]
+    else:
+        alllabels = labels
 
     if control is not None:
         explist = load_path(control)

--- a/runauto_cli.py
+++ b/runauto_cli.py
@@ -40,6 +40,10 @@ parser.add_argument('--init', type=str, default='lhs')
 parser.add_argument('--resume', type=str)
 parser.add_argument('--instrument', type=str, default='MAGIK')
 parser.add_argument('--oversampling', type=int, default=11)
+parser.add_argument('--qmin', type=float, default=0.008)
+parser.add_argument('--qmax', type=float, default=0.25)
+parser.add_argument('--qstep', type=float, default=0.0005)
+parser.add_argument('--qstep_max', type=float, default=None)
 args = parser.parse_args()
 
 # define fit options dictionary
@@ -82,20 +86,14 @@ if __name__ == '__main__':
         # condition selection array
         sel = np.array(args.sel) if args.sel is not None else None
 
+        # set measQ
+        qstep_max = args.qstep if args.qstep_max is None else args.qstep_max
+        dq = np.linspace(args.qstep, qstep_max, int(np.ceil(2 * (args.qmax - args.qmin) / (qstep_max + args.qstep))))
+        measQ = (args.qmin-args.qstep) + np.cumsum(dq)
+        #measQ = [m.fitness.probe.Q for m in model.models]
+
         # simulated experiment
         if not args.control:
-
-            # calculation vector
-            # TODO: figure out how to specify this in the cli
-            #measQ = np.linspace(0.008, 0.25, 201)
-            qstep = 0.0005
-            qstep_max = 0.0024
-            qmax = 0.25
-            qmin = 0.008
-            dq = np.linspace(qstep,qstep_max, int(np.ceil(2*(qmax-qmin)/(qstep_max+qstep))))
-            measQ = (qmin-qstep) + np.cumsum(dq)
-            #measQ = np.arange(0.008, 0.5005, 0.0005)
-#            measQ = [m.fitness.probe.Q for m in model.models]  
 
             for kk in range(args.nrepeats):
                 exp = SimReflExperiment(model, measQ, instrument=instr, eta=args.eta, fit_options=fit_options, oversampling=args.oversampling, bestpars=bestp, select_pars=sel, meas_bkg=meas_bkg, switch_penalty=args.penalty, npoints=args.npoints)
@@ -125,7 +123,7 @@ if __name__ == '__main__':
                     print('Rep: %i, Step: %i, Total time so far: %0.1f' % (kk, k, total_t))
                     exp.fit_step()
                     #exp.instrument.x = None # to turn off movement penalty
-                    exp.take_step()
+                    exp.take_step(allow_repeat=False)
                     exp.save(pathname + '/exp%i.pickle' % kk)
                     k += 1
 
@@ -138,17 +136,6 @@ if __name__ == '__main__':
 
         # control measurement
         else:
-            # calculation vector
-            if args.instrument == 'CANDOR':
-                qstep = 0.0005
-                qstep_max = 0.0024
-                qmax = 0.25
-                qmin = 0.008
-                dq = np.linspace(qstep,qstep_max, int(np.ceil(2*(qmax-qmin)/(qstep_max+qstep))))
-                measQ = (qmin-qstep) + np.cumsum(dq)
-            else:
-                measQ = [m.fitness.probe.Q for m in model.models]
-
             # meastimes
             meastimes = np.diff(np.insert(np.logspace(1, np.log10(args.maxtime), args.nctrlpts, endpoint=True), 0, 0))
 
@@ -164,7 +151,7 @@ if __name__ == '__main__':
                 if args.instrument == 'CANDOR':
                     for i, measQ in enumerate(exp.measQ):
                         x = list()
-                        overlap = 0.75
+                        overlap = 0.90
                         xrng = exp.instrument.qrange2xrange([min(measQ), max(measQ)])
                         x.append(xrng[0])
                         while x[-1] < xrng[1]:

--- a/runauto_cli.py
+++ b/runauto_cli.py
@@ -87,11 +87,21 @@ if __name__ == '__main__':
 
             # calculation vector
             # TODO: figure out how to specify this in the cli
-            measQ = np.linspace(0.008, 0.5, 401)
+            #measQ = np.linspace(0.008, 0.25, 201)
+            qstep = 0.0005
+            qstep_max = 0.0024
+            qmax = 0.25
+            qmin = 0.008
+            dq = np.linspace(qstep,qstep_max, int(np.ceil(2*(qmax-qmin)/(qstep_max+qstep))))
+            measQ = (qmin-qstep) + np.cumsum(dq)
+            #measQ = np.arange(0.008, 0.5005, 0.0005)
+#            measQ = [m.fitness.probe.Q for m in model.models]  
 
             for kk in range(args.nrepeats):
                 exp = SimReflExperiment(model, measQ, instrument=instr, eta=args.eta, fit_options=fit_options, oversampling=args.oversampling, bestpars=bestp, select_pars=sel, meas_bkg=meas_bkg, switch_penalty=args.penalty, npoints=args.npoints)
                 exp.switch_time_penalty = args.timepenalty # takes time to switch models
+                if args.instrument == 'MAGIK':
+                    exp.x = exp.measQ
                 exp.add_initial_step()
                 total_t = 0.0
                 k = 0

--- a/simexp.py
+++ b/simexp.py
@@ -858,7 +858,7 @@ class SimReflExperiment(object):
             xqprofs = newxqprofs
             pts = newpts
 
-            print(f'Forecast step {i} time: {time.time() - init_time}')
+            print(f'Forecast step {i}:\tNumber of curves: {newpts.shape[0]}\tCalculation time: {time.time() - init_time}')
             
         # reset instrument state
         self.instrument.x = org_x

--- a/simexp.py
+++ b/simexp.py
@@ -1178,7 +1178,8 @@ class SimReflExperimentControl(SimReflExperiment):
 
         self.meastimeweights = list()
         for x, weight in zip(self.x, model_weights):
-            self.meastimeweights.append(weight * np.array(x)**2 / np.sum(np.array(x)**2))
+            f = self.instrument.meastime(x, weight)
+            self.meastimeweights.append(f)
 
     def take_step(self, total_time):
         r"""Overrides SimReflExperiment.take_step
@@ -1418,7 +1419,7 @@ def snapshot(exp, stepnumber, fig=None, power=4, tscale='log'):
         idata = [[val for pt in plotpoints for val in getattr(pt, attr)] for attr in exp.attr_list]
         ar.plot_qprofiles(copy.copy(measQ), qprof, step.draw.logp, data=idata, ax=axtop, power=power)
         axtop.set_title(f'meas t = {steptimes[i]:0.0f} s\nmove t = {movetimes[i]:0.0f} s', fontsize='larger')
-        axbot.semilogy(x, fom, linewidth=3, color='C0')
+        axbot.plot(x, fom, linewidth=3, color='C0')
         if (j + 1) < len(exp.steps):
             newpoints = [pt for pt in exp.steps[j+1].points if ((pt.model == i) & (pt.merit is not None))]
             for newpt in newpoints:

--- a/simexp.py
+++ b/simexp.py
@@ -442,8 +442,11 @@ class SimReflExperiment(object):
         step = self.steps[-1]
         
         # Calculate figures of merit and proposed measurement times
+        print('Calculating figures of merit:')
+        init_time = time.time()
         step.foms, step.meastimes = self.calc_foms(step)
-
+        print('Calculation time: %f' % (time.time() - init_time))
+        
         # Apply the minimum measurement time
         # TODO: Consider whether the minimum measurement time should be tied to the movement time?
         min_meas_times = [np.maximum(np.full_like(meastime, self.min_meas_time), meastime) for meastime in step.meastimes]
@@ -770,7 +773,7 @@ class SimReflExperiment(object):
             refl = qprof/(1+2/sbr)
             refl = np.clip(refl, a_min=0, a_max=None)
 
-            interp_refl = interp1d(Qth, refl, axis=1)
+            interp_refl = interp1d(Qth, refl, axis=1, fill_value=(refl[:,0], refl[:,-1]), bounds_error=False)
             interp_refl_std = interp1d(m.fitness.probe.Q, sdR, fill_value=(sdR[0], sdR[-1]), bounds_error=False)
             
 

--- a/simexp.py
+++ b/simexp.py
@@ -735,14 +735,16 @@ class SimReflExperiment(object):
             fom = list()
             meas_time = list()
             for x, intens in zip(xs, incident_neutrons):
-                q = self.instrument.x2q(x)
+                q = np.squeeze(self.instrument.x2q(x))
                 #xrefl = intens * np.interp(q, Qth, refl * (minstd/np.mean(qprof, axis=0))**2)
                 # TODO: check this. Should it be the average of xrefl, or the sum?
                 #old_meas_time.append(np.mean((1-self.eta) / (self.eta**2 * xrefl)))
-
+                
                 # calculate the figure of merit
-                xqprof = np.array(interp_refl(q), ndmin=2).T
-
+                xqprof = np.array(interp_refl(q))
+                if xqprof.ndim == 1:
+                    xqprof = xqprof[:,None]
+                
                 idHdt, its = self._dHdt(pts, xqprof, intens)
                 fom.append(np.sum(idHdt))
                 meas_time.append(np.mean(its))

--- a/simexp.py
+++ b/simexp.py
@@ -694,7 +694,7 @@ class SimReflExperiment(object):
                 iH = ar.calc_entropy(pts[crit, :], select_pars=self.sel)
             else:
                 # calculate probability density of new distribution
-                p = (2 * np.pi * meas_sigma ** 2) * np.exp(-(iqs_sorted - med) ** 2 / (2 * meas_sigma) ** 2)
+                p = (2 * np.pi * meas_sigma ** 2) ** -0.5 * np.exp(-(iqs_sorted - med) ** 2 / (2 * meas_sigma ** 2))
 
                 # perform resampling
                 iHs = list()

--- a/simexp.py
+++ b/simexp.py
@@ -621,7 +621,6 @@ class SimReflExperiment(object):
         """ Calculate rate of change of entropy (dH/dt) for measuring at a given Q point
         
         Inputs:
-        Qth -- the Q values represented by each Q profile (length nQ array)
         pts -- the parameter samples underlying each Q profile (nprof x npar array)
         qprofs -- Q profiles (nprof x nQ array)
         incident_neutrons -- intensity ()
@@ -631,7 +630,8 @@ class SimReflExperiment(object):
         n_steps -- (ignored for now) optional parameter defaults to 1: number of forward steps to look
         
         Returns:
-        ????
+        dHdt -- array of dH/dt values for each Q point in qprofs
+        ts -- array of measurement time values for each Q point in qprofs
         """
 
         eta = self.eta  # measure to specified level
@@ -680,7 +680,7 @@ class SimReflExperiment(object):
                     r1idxs = np.unique(r1idxs)
                     
                     # select corresponding parameter values
-                    newpts = pts[r1idxs]
+                    newpts = pts[r1idxs, :]
 
                     # calculate marginalized entropy of selected points
                     iH = ar.calc_entropy(newpts, select_pars=self.sel)

--- a/simexp.py
+++ b/simexp.py
@@ -817,7 +817,7 @@ class SimReflExperiment(object):
                 fom.append(np.sum(idHdt - iddHdt))
                 meas_time.append(1./np.sum(1./its))
 
-            foms.append(fom)
+            foms.append(np.array(fom))
             meas_times.append(np.array(meas_time))
 
         return foms, meas_times


### PR DESCRIPTION
Directly calculating dH/dt is a better use of the MCMC sampling to calculate a figure of merit than the original linear regression / Jacobian scheme. Major changes in this PR include:

simexp.py:
o dH/dt as the figure of merit
o repeat measurement points disallowed for stability

runauto_cli.py:
o improved cli
o progressive q binning for all instruments
o overlapping q ranges for CANDOR control measurements

plot_entropy.py:
o now has a cli for specifying simulations and controls separately

simexp.py + instrument.py:
o instrument.py now used to define a "typical" measurement weighting scheme for control measurements